### PR TITLE
Frontend: Add power consumption estimation, fix darkmode

### DIFF
--- a/led_controller/public/index.html
+++ b/led_controller/public/index.html
@@ -68,11 +68,11 @@
                             <td class="px-6 py-4 whitespace-nowrap font-mono text-blue-500" id="elapsed">Loading...</td>
                         </tr>
                         <tr>
-                            <td class="px-6 py-4 whitespace-nowrap">Estimated power consumption:</td>
+                            <td class="px-6 py-4 whitespace-nowrap">Estimated power consumption (static white):</td>
                             <td class="px-6 py-4 whitespace-nowrap font-mono text-blue-500" id="consumption">Loading...</td>
                         </tr>
                         <tr>
-                            <td class="px-6 py-4 whitespace-nowrap">Estimated total power consumption:</td>
+                            <td class="px-6 py-4 whitespace-nowrap">Estimated total power consumption (static white):</td>
                             <td class="px-6 py-4 whitespace-nowrap font-mono text-blue-500" id="totalConsumption">Loading...</td>
                         </tr>
                     </tbody>


### PR DESCRIPTION
This PR updates darkmode to remember user choice and lets clearing it. Power consumption is now estimated assuming static white color and taking brightness in linear dependency (50% brightness = 50% * 60 mA per LED)